### PR TITLE
MinPrice  always 0.0 - Fixed.

### DIFF
--- a/src/main/java/com/shapira/examples/streams/stockstats/model/TradeStats.java
+++ b/src/main/java/com/shapira/examples/streams/stockstats/model/TradeStats.java
@@ -22,6 +22,8 @@ public class TradeStats {
         if (!this.type.equals(trade.type) || !this.ticker.equals(trade.ticker))
             throw new IllegalArgumentException("Aggregating stats for trade type " + this.type + " and ticker " + this.ticker + " but recieved trade of type " + trade.type +" and ticker " + trade.ticker );
 
+        if (countTrades == 0) this.minPrice = trade.getPrice();
+        
         this.countTrades = this.countTrades+1;
         this.sumPrice = this.sumPrice + trade.price;
         this.minPrice = this.minPrice < trade.price ? this.minPrice : trade.price;


### PR DESCRIPTION
Fixed the issue by setting the initial minPrice to initial tradePrice 

Before fix
{"ticker":"ADBE","timestamp":1497889268000}	{"type":"ASK","ticker":"ADBE","countTrades":5,"sumPrice":25048.832804120095,"minPrice":0.0,"avgPrice":5009.766560824019}
{"ticker":"AAP","timestamp":1497889268000}	{"type":"ASK","ticker":"AAP","countTrades":5,"sumPrice":25022.526076572653,"minPrice":0.0,"avgPrice":5004.505215314531}

After fix
{"ticker":"ADBE","timestamp":1497889268000}	{"type":"ASK","ticker":"ADBE","countTrades":5,"sumPrice":25048.832804120095,"minPrice":5008.99159716794,"avgPrice":5009.766560824019}
{"ticker":"AAP","timestamp":1497889268000}	{"type":"ASK","ticker":"AAP","countTrades":5,"sumPrice":25022.526076572653,"minPrice":5003.940740937474,"avgPrice":5004.505215314531}